### PR TITLE
Add public method to get express instance

### DIFF
--- a/lib/core/bot.js
+++ b/lib/core/bot.js
@@ -2,7 +2,6 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("@broid/utils");
 const Promise = require("bluebird");
-const bodyParser = require("body-parser");
 const express = require("express");
 const R = require("ramda");
 const Rx_1 = require("rxjs/Rx");
@@ -23,6 +22,12 @@ class Bot {
     }
     getHTTPEndpoints() {
         return this.httpEndpoints;
+    }
+    getExpress() {
+        if (!this.express) {
+            this.express = express();
+        }
+        return this.express;
     }
     use(instance, filter) {
         if (instance.listen) {
@@ -219,14 +224,9 @@ class Bot {
         this.integrations.push(integration);
         const router = integration.getRouter();
         if (router) {
-            if (!this.express) {
-                this.express = express();
-                this.express.use(bodyParser.json());
-                this.express.use(bodyParser.urlencoded({ extended: false }));
-            }
             const httpPath = `/webhook/${integration.serviceName()}`;
             this.httpEndpoints.push(httpPath);
-            this.express.use(httpPath, router);
+            this.getExpress().use(httpPath, router);
         }
         return;
     }
@@ -313,8 +313,8 @@ class Bot {
             .map((data) => ({ data, message }));
     }
     startHttpServer() {
-        if (this.express && !this.httpServer) {
-            this.httpServer = this.express.listen(this.httpOptions.port, this.httpOptions.host, () => {
+        if (!this.httpServer) {
+            this.httpServer = this.getExpress().listen(this.httpOptions.port, this.httpOptions.host, () => {
                 this.logger
                     .info(`Server listening on port ${this.httpOptions.host}:${this.httpOptions.port}...`);
             });

--- a/lib/core/bot.js
+++ b/lib/core/bot.js
@@ -194,9 +194,10 @@ class Bot {
         }
         return Promise.reject('Message should follow broid-schemas.');
     }
-    sendMedia(url, mediaType, message, meta) {
-        return this.processOutgoingContent(url, message)
+    sendMedia(url_, mediaType, message, meta) {
+        return this.processOutgoingContent(url_, message)
             .then((urlUpdated) => {
+            const url = urlUpdated.url || url_;
             let data = {
                 '@context': 'https://www.w3.org/ns/activitystreams',
                 'generator': {
@@ -206,9 +207,9 @@ class Bot {
                 },
                 'object': {
                     content: R.prop('content', meta),
-                    title: R.prop('title', meta),
+                    name: R.prop('name', meta),
                     type: mediaType,
-                    url: urlUpdated,
+                    url: url,
                 },
                 'to': {
                     id: R.path(['target', 'id'], message),

--- a/src/core/Bot.ts
+++ b/src/core/Bot.ts
@@ -5,7 +5,6 @@ import {
 import { Logger } from '@broid/utils';
 
 import * as Promise from 'bluebird';
-import * as bodyParser from 'body-parser';
 import * as express from 'express';
 import * as http from 'http';
 import * as R from 'ramda';
@@ -29,8 +28,8 @@ const isPromise = (obj: any): boolean =>
 export class Bot {
   public httpEndpoints: string[];
   public httpServer: null | http.Server;
+  public express: any;
 
-  private express: any;
   private httpOptions: IHTTPOptions;
   private integrations: any;
   private logLevel: string;
@@ -55,6 +54,13 @@ export class Bot {
 
   public getHTTPEndpoints(): string[] {
     return this.httpEndpoints;
+  }
+
+  public getExpress(): any {
+    if (!this.express) {
+      this.express = express();
+    }
+    return this.express;
   }
 
   public use(instance: any, filter?: string | string[]): void {
@@ -307,15 +313,9 @@ export class Bot {
 
     const router = integration.getRouter();
     if (router) {
-      if (!this.express) {
-        this.express = express();
-        this.express.use(bodyParser.json());
-        this.express.use(bodyParser.urlencoded({ extended: false }));
-      }
-
       const httpPath = `/webhook/${integration.serviceName()}`;
       this.httpEndpoints.push(httpPath);
-      this.express.use(httpPath, router);
+      this.getExpress().use(httpPath, router);
     }
 
     return;
@@ -432,8 +432,8 @@ export class Bot {
   }
 
   private startHttpServer(): void {
-    if (this.express && !this.httpServer) {
-      this.httpServer = this.express.listen(this.httpOptions.port, this.httpOptions.host,
+    if (!this.httpServer) {
+      this.httpServer = this.getExpress().listen(this.httpOptions.port, this.httpOptions.host,
         () => {
           this.logger
             .info(`Server listening on port ${this.httpOptions.host}:${this.httpOptions.port}...`);

--- a/src/core/Bot.ts
+++ b/src/core/Bot.ts
@@ -278,11 +278,13 @@ export class Bot {
     return Promise.reject('Message should follow broid-schemas.');
   }
 
-  private sendMedia(url: string, mediaType: string,
+  private sendMedia(url_: string, mediaType: string,
                     message: IActivityStream,
                     meta?: IMetaMediaSend): Promise<any> {
-    return this.processOutgoingContent(url, message)
+    return this.processOutgoingContent(url_, message)
       .then((urlUpdated) => {
+        const url: string = urlUpdated.url || url_;
+
         let data: ISendParameters = {
           '@context': 'https://www.w3.org/ns/activitystreams',
           'generator': {
@@ -292,9 +294,9 @@ export class Bot {
           },
           'object': {
             content: R.prop('content', meta),
-            title: R.prop('title', meta),
+            name: R.prop('name', meta),
             type: mediaType,
-            url: urlUpdated,
+            url: url,
           },
           'to': {
             id: R.path(['target', 'id'], message),
@@ -304,6 +306,7 @@ export class Bot {
         };
 
         data = this.addMessageContext(data, message);
+
         return this.send(data);
       });
   }


### PR DESCRIPTION
Allow accessing to express instance to add middlewares if necessary.
This put compatible `@broid/kik` wich has an issue with `body-parser` (https://github.com/kikinteractive/kik-node/issues/8)

```js

const R = require('ramda');
const BroidKik = require('@broid/slack');
const Bot = require("@broid/kit");
const bodyParser = require("body-parser");

const bot = new Bot({
	logLevel: "info",
	http: {
		host: "0.0.0.0",
		port: 8080,
	}
});

bot.getExpress().use(bodyParser.json());
bot.getExpress().use(bodyParser.urlencoded({ extended: false }));

```