### PR TITLE
add getRouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,40 @@ bot.hear("hello.*", "Group")
   });
 ```
 
+Broid-Kit can also be used with your existing Express setup.
+
+```javascript
+
+const Bot = require("@broid/kit");
+const BroidDiscord = require("@broid/discord");
+const BroidMessenger = require("@broid/messenger");
+const BroidSlack = require("@broid/slack");
+const express = require("express");
+
+const bot = new Bot({
+  logLevel: "info"
+});
+
+bot.use(new BroidDiscord({...options}));
+bot.use(new BroidMessenger({...options}));
+bot.use(new BroidSlack({...options}));
+
+// Setup express
+const app = express();
+app.use("/", bot.getRouter());
+app.listen(8080);
+
+// Listening for public starting by regex match for `hello`
+bot.hear("hello.*", "Group")
+  .subscribe((data) => {
+    console.log("Data:", JSON.stringify(data, null, 2));
+
+    // Reply to the message
+    bot.sendText("Hi, How are you?", data.message);
+  });
+```
+
+
 ## Documentation
 
 ### Receive all group messages

--- a/lib/core/bot.js
+++ b/lib/core/bot.js
@@ -15,14 +15,22 @@ class Bot {
         this.integrations = [];
         this.incomingMiddlewares = [];
         this.outgoingMiddlewares = [];
-        const httpOptions = { host: '0.0.0.0', port: 8080 };
-        this.httpOptions = obj && obj.http || httpOptions;
+        this.router = express.Router();
         this.httpEndpoints = [];
         this.httpServer = null;
+        if (obj && obj.http) {
+            this.startHttpServer(obj.http);
+        }
         this.logger = new utils_1.Logger('broidkit', this.logLevel);
     }
     getHTTPEndpoints() {
         return this.httpEndpoints;
+    }
+    getRouter() {
+        if (this.httpServer) {
+            return null;
+        }
+        return this.router;
     }
     use(instance, filter) {
         if (instance.listen) {
@@ -146,7 +154,6 @@ class Bot {
         };
     }
     processListener(listener, callback) {
-        this.startHttpServer();
         if (callback) {
             listener.subscribe(callback, (error) => callback(null, error));
             return true;
@@ -217,16 +224,14 @@ class Bot {
     }
     addIntegration(integration) {
         this.integrations.push(integration);
+        if (!integration.getRouter) {
+            return;
+        }
         const router = integration.getRouter();
         if (router) {
-            if (!this.express) {
-                this.express = express();
-                this.express.use(bodyParser.json());
-                this.express.use(bodyParser.urlencoded({ extended: false }));
-            }
             const httpPath = `/webhook/${integration.serviceName()}`;
             this.httpEndpoints.push(httpPath);
-            this.express.use(httpPath, router);
+            this.router.use(httpPath, router);
         }
         return;
     }
@@ -312,11 +317,14 @@ class Bot {
             .take(1)
             .map((data) => ({ data, message }));
     }
-    startHttpServer() {
-        if (this.express && !this.httpServer) {
-            this.httpServer = this.express.listen(this.httpOptions.port, this.httpOptions.host, () => {
-                this.logger
-                    .info(`Server listening on port ${this.httpOptions.host}:${this.httpOptions.port}...`);
+    startHttpServer(httpOptions) {
+        if (!this.httpServer) {
+            const app = express();
+            app.use(bodyParser.json());
+            app.use(bodyParser.urlencoded({ extended: false }));
+            app.use(this.router);
+            this.httpServer = app.listen(httpOptions.port, httpOptions.host, () => {
+                this.logger.info(`Server listening on port ${httpOptions.host}:${httpOptions.port}...`);
             });
         }
     }

--- a/src/core/Bot.ts
+++ b/src/core/Bot.ts
@@ -28,10 +28,9 @@ const isPromise = (obj: any): boolean =>
 
 export class Bot {
   public httpEndpoints: string[];
-  public httpServer: null | http.Server;
+  public httpServer: http.Server | null;
 
-  private express: any;
-  private httpOptions: IHTTPOptions;
+  private router: express.Router;
   private integrations: any;
   private logLevel: string;
   private logger: Logger;
@@ -45,16 +44,26 @@ export class Bot {
     this.incomingMiddlewares = [];
     this.outgoingMiddlewares = [];
 
-    const httpOptions: IHTTPOptions = { host: '0.0.0.0', port: 8080 };
-    this.httpOptions = obj && obj.http || httpOptions;
+    this.router = express.Router();
     this.httpEndpoints = [];
     this.httpServer = null;
+    if (obj && obj.http) {
+      this.startHttpServer(obj.http);
+    }
 
     this.logger = new Logger('broidkit', this.logLevel);
   }
 
   public getHTTPEndpoints(): string[] {
     return this.httpEndpoints;
+  }
+
+  public getRouter(): express.Router | null {
+    if (this.httpServer) {
+      return null;
+    }
+
+    return this.router;
   }
 
   public use(instance: any, filter?: string | string[]): void {
@@ -211,10 +220,6 @@ export class Bot {
 
   private processListener(listener: Observable<IActivityStream>,
                           callback?: callbackType): Observable<IActivityStream> | boolean {
-
-    // Start the http server
-    this.startHttpServer();
-
     if (callback) {
       listener.subscribe(callback, (error) => callback(null, error));
       return true;
@@ -304,18 +309,15 @@ export class Bot {
 
   private addIntegration(integration: any): void {
     this.integrations.push(integration);
+    if (!integration.getRouter) {
+      return;
+    }
 
     const router = integration.getRouter();
     if (router) {
-      if (!this.express) {
-        this.express = express();
-        this.express.use(bodyParser.json());
-        this.express.use(bodyParser.urlencoded({ extended: false }));
-      }
-
       const httpPath = `/webhook/${integration.serviceName()}`;
       this.httpEndpoints.push(httpPath);
-      this.express.use(httpPath, router);
+      this.router.use(httpPath, router);
     }
 
     return;
@@ -431,13 +433,16 @@ export class Bot {
       .map((data: any) => ({ data, message }));
   }
 
-  private startHttpServer(): void {
-    if (this.express && !this.httpServer) {
-      this.httpServer = this.express.listen(this.httpOptions.port, this.httpOptions.host,
-        () => {
-          this.logger
-            .info(`Server listening on port ${this.httpOptions.host}:${this.httpOptions.port}...`);
-        });
+  private startHttpServer(httpOptions: IHTTPOptions): void {
+    if (!this.httpServer) {
+      const app: express = express();
+      app.use(bodyParser.json());
+      app.use(bodyParser.urlencoded({ extended: false }));
+      app.use(this.router);
+
+      this.httpServer = app.listen(httpOptions.port, httpOptions.host, () => {
+        this.logger.info(`Server listening on port ${httpOptions.host}:${httpOptions.port}...`);
+      });
     }
   }
 


### PR DESCRIPTION
## Overview

Adds `getRouter` method in the same way that the Broid Integrations do. This introduces breaking changes as an HTTP server is no longer created by default. HTTP options are required in order for Broid Kit to create one.

This also fixes the bug where Broid Kit doesn't work correctly if the integration doesn't need a webhook server.