### PR TITLE
Add id to outbound object

### DIFF
--- a/lib/core/bot.js
+++ b/lib/core/bot.js
@@ -98,6 +98,7 @@ class Bot {
                 },
                 'object': {
                     content,
+                    id: R.path(['object', 'id'], message),
                     type: 'Note',
                 },
                 'to': {

--- a/src/core/Bot.ts
+++ b/src/core/Bot.ts
@@ -152,6 +152,7 @@ export class Bot {
           },
           'object': {
             content,
+            id: R.path(['object', 'id'], message),
             type: 'Note',
           },
           'to': {


### PR DESCRIPTION
## Overview

Adds the `id` to `object.id` if available. Use case example is replying to Slack threads. Related: https://github.com/broidHQ/integrations/pull/152