### PR TITLE
Fix/process listener

### DIFF
--- a/lib/core/Bot.d.ts
+++ b/lib/core/Bot.d.ts
@@ -8,7 +8,7 @@ export declare class Bot {
     httpEndpoints: string[];
     httpServer: http.Server | null;
     private router;
-    private integrations;
+    integrations: any;
     private logLevel;
     private logger;
     private outgoingMiddlewares;
@@ -17,9 +17,9 @@ export declare class Bot {
     getHTTPEndpoints(): string[];
     getRouter(): express.Router | null;
     use(instance: any, filter?: string | string[]): void;
-    hear(pattern: string | boolean, messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream> | boolean;
-    hears(patterns: string[], messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream> | boolean;
-    on(messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream> | boolean;
+    hear(pattern: string | boolean, messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream>;
+    hears(patterns: string[], messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream>;
+    on(messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream>;
     sendText(text: string, message: IActivityStream): any;
     sendVideo(url: string, message: IActivityStream, meta?: IMetaMediaSend): any;
     sendImage(url: string, message: IActivityStream, meta?: IMetaMediaSend): any;

--- a/lib/core/Bot.js
+++ b/lib/core/Bot.js
@@ -157,7 +157,6 @@ class Bot {
     processListener(listener, callback) {
         if (callback) {
             listener.subscribe(callback, (error) => callback(null, error));
-            return true;
         }
         return listener;
     }

--- a/lib/core/interfaces.d.ts
+++ b/lib/core/interfaces.d.ts
@@ -16,6 +16,6 @@ export interface IMetaMediaSend {
     content?: string;
 }
 export interface IOptions {
-    logLevel: string;
+    logLevel?: string;
     http?: IHTTPOptions;
 }

--- a/src/core/Bot.ts
+++ b/src/core/Bot.ts
@@ -31,7 +31,7 @@ export class Bot {
   public httpServer: http.Server | null;
 
   private router: express.Router;
-  private integrations: any;
+  public integrations: any;
   private logLevel: string;
   private logger: Logger;
   private outgoingMiddlewares: any;
@@ -94,7 +94,7 @@ export class Bot {
   // messageTypes => Image, Video, Group, Private, Mention etc...
   public hear(pattern: string | boolean,
               messageTypes?: string | callbackType,
-              cb?: callbackType): Observable<IActivityStream> | boolean  {
+              cb?: callbackType): Observable<IActivityStream>  {
     const args: IListenerArgs = this.processArgs(messageTypes, cb);
     const messageTypesArr: string[] = this.messageTypes2Arr(R.prop('msgTypes', args) as string);
 
@@ -118,7 +118,7 @@ export class Bot {
 
   public hears(patterns: string[],
                messageTypes?: string | callbackType,
-               cb?: callbackType): Observable<IActivityStream> | boolean  {
+               cb?: callbackType): Observable<IActivityStream>  {
     const args: IListenerArgs = this.processArgs(messageTypes, cb);
     const messageTypesArr: string[] = this.messageTypes2Arr(R.prop('msgTypes', args) as string);
     const patternRegexes: RegExp[] = R.map((pattern: string) =>
@@ -144,7 +144,7 @@ export class Bot {
   }
 
   public on(messageTypes?: string | callbackType,
-            cb?: callbackType): Observable<IActivityStream> | boolean  {
+            cb?: callbackType): Observable<IActivityStream>  {
     return this.hear(true, messageTypes, cb);
   }
 
@@ -220,10 +220,9 @@ export class Bot {
   }
 
   private processListener(listener: Observable<IActivityStream>,
-                          callback?: callbackType): Observable<IActivityStream> | boolean {
+                          callback?: callbackType): Observable<IActivityStream> {
     if (callback) {
       listener.subscribe(callback, (error) => callback(null, error));
-      return true;
     }
     return listener;
   }

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -25,6 +25,6 @@ export interface IMetaMediaSend {
 }
 
 export interface IOptions {
-  logLevel: string;
+  logLevel?: string;
   http?: IHTTPOptions;
 }


### PR DESCRIPTION
Fixes config interface.
Removes `boolean` as a returned value for `processListener` as it's not needed and breaks typings.