### PR TITLE
Fixed return type of method on

### DIFF
--- a/lib/core/Bot.d.ts
+++ b/lib/core/Bot.d.ts
@@ -3,7 +3,7 @@ import { IActivityStream } from '@broid/schemas';
 import * as express from 'express';
 import * as http from 'http';
 import { Observable } from 'rxjs/Rx';
-import { callbackType, IMetaMediaSend, IOptions } from './interfaces';
+import { callbackType, IMetaMediaSend, IOptions, IMessage } from './interfaces';
 export declare class Bot {
     httpEndpoints: string[];
     httpServer: http.Server | null;
@@ -17,9 +17,9 @@ export declare class Bot {
     getHTTPEndpoints(): string[];
     getRouter(): express.Router | null;
     use(instance: any, filter?: string | string[]): void;
-    hear(pattern: string | boolean, messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream>;
+    hear(pattern: string | boolean, messageTypes?: string | callbackType, cb?: callbackType): Observable<IMessage>;
     hears(patterns: string[], messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream>;
-    on(messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream>;
+    on(messageTypes?: string | callbackType, cb?: callbackType): Observable<IMessage>;
     sendText(text: string, message: IActivityStream): any;
     sendVideo(url: string, message: IActivityStream, meta?: IMetaMediaSend): any;
     sendImage(url: string, message: IActivityStream, meta?: IMetaMediaSend): any;

--- a/lib/core/interfaces.d.ts
+++ b/lib/core/interfaces.d.ts
@@ -19,3 +19,7 @@ export interface IOptions {
     logLevel?: string;
     http?: IHTTPOptions;
 }
+export interface IMessage {
+    data: any;
+    message: IActivityStream;
+}

--- a/src/core/Bot.ts
+++ b/src/core/Bot.ts
@@ -17,6 +17,7 @@ import {
   IListenerArgs,
   IMetaMediaSend,
   IOptions,
+  IMessage,
   middlewareIncomingType,
   middlewareOutgoingType,
 } from './interfaces';
@@ -94,7 +95,7 @@ export class Bot {
   // messageTypes => Image, Video, Group, Private, Mention etc...
   public hear(pattern: string | boolean,
               messageTypes?: string | callbackType,
-              cb?: callbackType): Observable<IActivityStream>  {
+              cb?: callbackType): Observable<IMessage>  {
     const args: IListenerArgs = this.processArgs(messageTypes, cb);
     const messageTypesArr: string[] = this.messageTypes2Arr(R.prop('msgTypes', args) as string);
 
@@ -144,7 +145,7 @@ export class Bot {
   }
 
   public on(messageTypes?: string | callbackType,
-            cb?: callbackType): Observable<IActivityStream>  {
+            cb?: callbackType): Observable<IMessage>  {
     return this.hear(true, messageTypes, cb);
   }
 
@@ -350,7 +351,7 @@ export class Bot {
     .concatMap((value: any) => value);
   }
 
-  private processIncomingMessage(message: IActivityStream): Observable<any> {
+  private processIncomingMessage(message: IActivityStream): Observable<IMessage> {
     const middlewares = R.map((middleware: any) => {
       return (acc: any) => {
         let resultObservable = Observable.empty();

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -28,3 +28,8 @@ export interface IOptions {
   logLevel?: string;
   http?: IHTTPOptions;
 }
+
+export interface IMessage {
+  data: any;
+  message: IActivityStream;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "removeComments": true,
-    "preserveConstEnums": true,
     "moduleResolution": "node",
     "target": "es2015",
     "module": "commonjs",


### PR DESCRIPTION
It was a typescript error:
```js
bot.on('Person').subscribe((data) => {
  data // type is IActivityStream
  data.message // error, because this property is missing in IActivityStream
});
```

In fact, `data` is object like below:
```json
{
  "data": [],
  "message": {
    "@context": "https://www.w3.org/ns/activitystreams",
    "generator": {
      "id": "45c061a7-945d-4f7c-8e09-e28162b0d",
      "name": "telegram",
      "type": "Service"
    },
    "published": 1515652,
    "type": "Create",
    "actor": {
      "id": "63580",
      "name": "Artem Kurbatov",
      "type": "Person"
    },
    "target": {
      "id": "63580",
      "name": "Artem Kurbatov",
      "type": "Person"
    },
    "object": {
      "content": "text",
      "id": "243",
      "type": "Note"
    }
  }
}
```