### PR TITLE
Fixed params types of send-methods

### DIFF
--- a/lib/core/Bot.d.ts
+++ b/lib/core/Bot.d.ts
@@ -3,7 +3,7 @@ import { IActivityStream } from '@broid/schemas';
 import * as express from 'express';
 import * as http from 'http';
 import { Observable } from 'rxjs/Rx';
-import { callbackType, IMetaMediaSend, IOptions, IMessage } from './interfaces';
+import { callbackType, IMessage, IMetaMediaSend, IOptions, ISendData } from './interfaces';
 export declare class Bot {
     httpEndpoints: string[];
     httpServer: http.Server | null;
@@ -20,9 +20,9 @@ export declare class Bot {
     hear(pattern: string | boolean, messageTypes?: string | callbackType, cb?: callbackType): Observable<IMessage>;
     hears(patterns: string[], messageTypes?: string | callbackType, cb?: callbackType): Observable<IActivityStream>;
     on(messageTypes?: string | callbackType, cb?: callbackType): Observable<IMessage>;
-    sendText(text: string, message: IActivityStream): any;
-    sendVideo(url: string, message: IActivityStream, meta?: IMetaMediaSend): any;
-    sendImage(url: string, message: IActivityStream, meta?: IMetaMediaSend): any;
+    sendText(text: string, message: ISendData): any;
+    sendVideo(url: string, message: ISendData, meta?: IMetaMediaSend): any;
+    sendImage(url: string, message: ISendData, meta?: IMetaMediaSend): any;
     private processOutgoingContent(content, message);
     private messageTypes2Arr(messageTypes?);
     private processArgs(msgTypes?, cb?);

--- a/lib/core/interfaces.d.ts
+++ b/lib/core/interfaces.d.ts
@@ -1,4 +1,4 @@
-import { IActivityStream } from '@broid/schemas';
+import { IActivityStream, IASContext } from '@broid/schemas';
 import { Observable } from 'rxjs/Rx';
 export declare type callbackType = (message: any, error?: any) => any;
 export declare type middlewareIncomingType = (bot: any, message: any, acc?: any) => Promise<any> | Observable<any>;
@@ -22,4 +22,18 @@ export interface IOptions {
 export interface IMessage {
     data: any;
     message: IActivityStream;
+}
+export interface ISendData {
+    generator: {
+        id: string;
+        name: string;
+    };
+    target: {
+        id: string;
+        type: string;
+    };
+    object?: {
+        id: string;
+        context: IASContext;
+    };
 }

--- a/src/core/Bot.ts
+++ b/src/core/Bot.ts
@@ -15,9 +15,10 @@ import {
   callbackType,
   IHTTPOptions,
   IListenerArgs,
+  IMessage,
   IMetaMediaSend,
   IOptions,
-  IMessage,
+  ISendData,
   middlewareIncomingType,
   middlewareOutgoingType,
 } from './interfaces';
@@ -149,7 +150,7 @@ export class Bot {
     return this.hear(true, messageTypes, cb);
   }
 
-  public sendText(text: string, message: IActivityStream) {
+  public sendText(text: string, message: ISendData) {
     return this.processOutgoingContent(text, message)
       .then((updated) => {
         const content: string = updated.content || text;
@@ -178,11 +179,11 @@ export class Bot {
       });
   }
 
-  public sendVideo(url: string, message: IActivityStream, meta?: IMetaMediaSend) {
+  public sendVideo(url: string, message: ISendData, meta?: IMetaMediaSend) {
     return this.sendMedia(url, 'Video', message, meta);
   }
 
-  public sendImage(url: string, message: IActivityStream, meta?: IMetaMediaSend) {
+  public sendImage(url: string, message: ISendData, meta?: IMetaMediaSend) {
     return this.sendMedia(url, 'Image', message, meta);
   }
 
@@ -279,7 +280,7 @@ export class Bot {
   }
 
   private sendMedia(url: string, mediaType: string,
-                    message: IActivityStream,
+                    message: ISendData,
                     meta: IMetaMediaSend = {}): Promise<any> {
     return this.processOutgoingContent(url, message)
       .then((updated: any) => {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,4 +1,4 @@
-import { IActivityStream } from '@broid/schemas';
+import { IActivityStream, IASContext } from '@broid/schemas';
 
 import { Observable } from 'rxjs/Rx';
 
@@ -32,4 +32,19 @@ export interface IOptions {
 export interface IMessage {
   data: any;
   message: IActivityStream;
+}
+
+export interface ISendData {
+  generator: {
+    id: string;
+    name: string;
+  };
+  target: {
+    id: string;
+    type: string;
+  };
+  object?: {
+    id: string;
+    context: IASContext;
+  };
 }


### PR DESCRIPTION
Currently parameter `message` in methods `sendText()`, `sendVideo()` and `sendImage()` requires to pass extra data, which is not used.